### PR TITLE
Updated code to work with newest version of eureka

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,28 @@ Register your service "my-service-name" with port 10100 at the Eureka server at 
 ```
 
 After registering, a heartbeat will automatically be sent every 20 seconds.
+The instance ID of the registered service is returned.
 
 Request all instances for "my-service-name" (after two instances have been registered):
 ```
 (eureka/find-instances "localhost" 8761 "my-service-name")
 
 ; => '({:ip "192.168.178.38" :port 10100} {:ip "192.168.178.38" :port 11100})
+```
+
+Delete instance "instance-id" of service "my-service-name" from the eureka server:
+```
+(eureka/delete-instance "localhost" 8761 "my-service-name" "instance-id")
+
+; => true
+```
+Returns success state.
+
+Change the server url of the eureka server. Standard is /eureka/v2/apps
+```
+(eureka/alter-server-path "/eureka-server/apps")
+
+; => "/eureka-server/apps"
 ```
 
 ## Contributing

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject eureka-client "0.3.0-SNAPSHOT"
+(defproject eureka-client "0.4.0-SNAPSHOT"
   :description "A client for Netflix Eureka service discovery servers"
   :url "http://github.com/codebrickie/eureka-client"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,11 @@
   :url "http://github.com/codebrickie/eureka-client"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-http "1.0.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [org.clojure/core.cache "0.6.4"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-midje "3.1.3"]
-                             [codox "0.8.10"]]}})
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "3.1.0"]
+                 [cheshire "5.6.3"]
+                 [org.clojure/core.cache "0.6.5"]]
+  :profiles {:dev {:dependencies [[midje "1.8.3"]]
+                   :plugins [[lein-midje "3.2"]
+                             [codox "0.9.6"]
+                             [lein-ancient "0.6.10"]]}})

--- a/test/eureka_client/core_test.clj
+++ b/test/eureka_client/core_test.clj
@@ -3,7 +3,7 @@
             [eureka-client.core :refer :all]
             [clj-http.client :as http]))
 
-(def example-response
+(def example-instance-response
   {:orig-content-encoding nil
    :request-time 8
    :status 200
@@ -64,6 +64,23 @@
                                     :countryId 1
                                     :app "MYID"}]}}})
 
+(def example-delete-response
+  {:request-time 13,
+   :repeatable? false,
+   :streaming? false,
+   :chunked? false,
+   :headers {"Server" "Apache-Coyote/1.1",
+             "Vary" "Accept-Encoding",
+             "Content-Type" "application/xml",
+             "Content-Length" "0",
+             "Date" "Tue, 16 Aug 2016 12:19:21 GMT",
+             "Connection" "close"},
+   :orig-content-encoding nil,
+   :status 200,
+   :length 0,
+   :body "",
+   :trace-redirects ["http://localhost:8080/eureka/v2/apps/blubber/127.0.1.1-2874"]})
+
 (def example-request
   {:form-params {:instance
                  {:hostName (str (.getHostAddress (java.net.InetAddress/getLocalHost)) "-" 1)
@@ -88,12 +105,17 @@
   (find-instances "localhost" 8761 "myId") => '({:ip "192.168.178.38" :port 10100}
                                                 {:ip "192.168.178.38" :port 11100})
     (provided
-      (http/get "http://localhost:8761/eureka/v2/apps/myId" anything) => example-response)
+      (http/get "http://localhost:8761/eureka/v2/apps/myId" anything) => example-instance-response)
 
   (find-instances "localhost" 8761 "myId") => '({:ip "192.168.178.38" :port 10100}
                                                 {:ip "192.168.178.38" :port 11100})
     (provided
       (http/get "http://localhost:8761/eureka/v2/apps/myId" anything) => anything :times 0))
+
+(fact "it deletes an instance from eureka"
+      (delete-instance "localhost" 8761 "myId" "127.0.1.1-4242") => true
+      (provided (http/delete "http://localhost:8761/eureka/v2/apps/myId/127.0.1.1-4242")
+                => example-delete-response))
 
 
 (with-state-changes [(before :facts (alter-server-path "/eureka/apps"))]
@@ -109,7 +131,7 @@
                           (find-instances "localhost" 8761 "otherId") => '({:ip "192.168.178.38" :port 10100}
                                                                          {:ip "192.168.178.38" :port 11100})
                           (provided
-                            (http/get "http://localhost:8761/eureka/apps/otherId" anything) => example-response)
+                            (http/get "http://localhost:8761/eureka/apps/otherId" anything) => example-instance-response)
 
                           (find-instances "localhost" 8761 "otherId") => '({:ip "192.168.178.38" :port 10100}
                                                                          {:ip "192.168.178.38" :port 11100})

--- a/test/eureka_client/core_test.clj
+++ b/test/eureka_client/core_test.clj
@@ -3,89 +3,115 @@
             [eureka-client.core :refer :all]
             [clj-http.client :as http]))
 
-
-(fact "it registers the app"
-  (register "localhost" 8761 "myId" 1234) => anything
-    (provided
-      (rand-int 10000) => 1
-      (http/post
-        "http://localhost:8761/eureka/apps/myId"
-        (contains {:form-params {:instance
-                                  {:hostName (str (.getHostAddress (java.net.InetAddress/getLocalHost)) "-" 1)
-                                   :app "myId"
-                                   :ipAddr (.getHostAddress (java.net.InetAddress/getLocalHost))
-                                   :vipAddress "myId"
-                                  :status "UP"
-                                  :port 1234
-                                  :securePort 443
-                                  :dataCenterInfo {:name "MyOwn"}}}})) => anything))
-
-(fact "it finds all instances of an app (second call cached)"
-  (find-instances "localhost" 8761 "myId") => '({:ip "192.168.178.38" :port 10100}
-                                                {:ip "192.168.178.38" :port 11100})
-    (provided
-      (http/get "http://localhost:8761/eureka/apps/myId" anything) =>
-                                                             {:orig-content-encoding nil
-                                                              :request-time 8
-                                                              :status 200
-                                                              :headers
-                                                               {"Connection" "close"
-                                                                "Date" "Tue, 11 Nov 2014 16:10:52 GMT"
-                                                                "Transfer-Encoding" "chunked"
-                                                                "Content-Type" "application/json"
-                                                                "Server" "Apache-Coyote/1.1"}
-                                                               :body
-                                                               {:application
-                                                                {:name "MYID"
-                                                                 :instance
-                                                                 [{:leaseInfo
+(def example-response
+  {:orig-content-encoding nil
+   :request-time 8
+   :status 200
+   :headers
+                          {"Connection" "close"
+                           "Date" "Tue, 11 Nov 2014 16:10:52 GMT"
+                           "Transfer-Encoding" "chunked"
+                           "Content-Type" "application/json"
+                           "Server" "Apache-Coyote/1.1"}
+   :body
+                          {:application
+                           {:name "MYID"
+                            :instance
+                                  [{:leaseInfo
                                                                    {:renewalIntervalInSecs 30
                                                                     :durationInSecs 90
                                                                     :registrationTimestamp 1415720281005
                                                                     :lastRenewalTimestamp 1415722261874
                                                                     :evictionTimestamp 0
                                                                     :serviceUpTimestamp 1415720280954}
-                                                                   :isCoordinatingDiscoveryServer false
-                                                                   :lastDirtyTimestamp 1415720280954
-                                                                   :securePort {:enabled "false" :$ "443"}
-                                                                   :dataCenterInfo
+                                    :isCoordinatingDiscoveryServer false
+                                    :lastDirtyTimestamp 1415720280954
+                                    :securePort {:enabled "false" :$ 443}
+                                    :dataCenterInfo
                                                                    {:class "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo"
                                                                     :name "MyOwn"}
-                                                                   :hostName "192.168.178.38-8107"
-                                                                   :ipAddr "192.168.178.38"
-                                                                   :port {:enabled "true" :$ "10100"}
-                                                                   :overriddenstatus "UNKNOWN"
-                                                                   :lastUpdatedTimestamp 1415720281005
-                                                                   :vipAddress "myid"
-                                                                   :status "UP"
-                                                                   :actionType "ADDED"
-                                                                   :countryId 1
-                                                                   :app "MYID"
-                                                                   :metadata {:class "java.util.Collections$EmptyMap"}}
-                                                                  {:leaseInfo
+                                    :hostName "192.168.178.38-8107"
+                                    :ipAddr "192.168.178.38"
+                                    :port {:enabled "true" :$ 10100}
+                                    :overriddenstatus "UNKNOWN"
+                                    :lastUpdatedTimestamp 1415720281005
+                                    :vipAddress "myid"
+                                    :status "UP"
+                                    :actionType "ADDED"
+                                    :countryId 1
+                                    :app "MYID"
+                                    :metadata {:class "java.util.Collections$EmptyMap"}}
+                                   {:leaseInfo
                                                                    {:renewalIntervalInSecs 30
                                                                     :durationInSecs 90
                                                                     :registrationTimestamp 1415720235036
                                                                     :lastRenewalTimestamp 1415722275398
                                                                     :evictionTimestamp 0
                                                                     :serviceUpTimestamp 1415720234504}
-                                                                   :isCoordinatingDiscoveryServer false
-                                                                   :lastDirtyTimestamp 1415720234500
-                                                                   :securePort {:enabled "false" :$ "443"}
-                                                                   :dataCenterInfo
+                                    :isCoordinatingDiscoveryServer false
+                                    :lastDirtyTimestamp 1415720234500
+                                    :securePort {:enabled "false" :$ 443}
+                                    :dataCenterInfo
                                                                    {:name "MyOwn"}
-                                                                   :hostName "192.168.178.38-2325"
-                                                                   :ipAddr "192.168.178.38"
-                                                                   :port {:enabled "true" :$ "11100"}
-                                                                   :overriddenstatus "UNKNOWN"
-                                                                   :lastUpdatedTimestamp 1415720235037
-                                                                   :vipAddress "myid"
-                                                                   :status "UP"
-                                                                   :actionType "ADDED"
-                                                                   :countryId 1
-                                                                   :app "MYID"}]}}})
+                                    :hostName "192.168.178.38-2325"
+                                    :ipAddr "192.168.178.38"
+                                    :port {:enabled "true" :$ 11100}
+                                    :overriddenstatus "UNKNOWN"
+                                    :lastUpdatedTimestamp 1415720235037
+                                    :vipAddress "myid"
+                                    :status "UP"
+                                    :actionType "ADDED"
+                                    :countryId 1
+                                    :app "MYID"}]}}})
+
+(def example-request
+  {:form-params {:instance
+                 {:hostName (str (.getHostAddress (java.net.InetAddress/getLocalHost)) "-" 1)
+                  :app "myId"
+                  :ipAddr (.getHostAddress (java.net.InetAddress/getLocalHost))
+                  :vipAddress "myId"
+                  :status "UP"
+                  :port {:$ 1234, "@enabled" "true"}
+                  :securePort {:$ 443, "@enabled" "true"}
+                  :dataCenterInfo {"@class" "com.netflix.appinfo.InstanceInfo$DefaultDataCenterInfo", :name "MyOwn"}}}})
+
+
+(fact "it registers the app"
+  (register "localhost" 8761 "myId" 1234) => anything
+    (provided
+      (rand-int 10000) => 1
+      (http/post
+        "http://localhost:8761/eureka/v2/apps/myId"
+        (contains example-request)) => anything))
+
+(fact "it finds all instances of an app (second call cached)"
+  (find-instances "localhost" 8761 "myId") => '({:ip "192.168.178.38" :port 10100}
+                                                {:ip "192.168.178.38" :port 11100})
+    (provided
+      (http/get "http://localhost:8761/eureka/v2/apps/myId" anything) => example-response)
 
   (find-instances "localhost" 8761 "myId") => '({:ip "192.168.178.38" :port 10100}
                                                 {:ip "192.168.178.38" :port 11100})
     (provided
-      (http/get "http://localhost:8761/eureka/apps/myId" anything) => anything :times 0))
+      (http/get "http://localhost:8761/eureka/v2/apps/myId" anything) => anything :times 0))
+
+
+(with-state-changes [(before :facts (alter-server-path "/eureka/apps"))]
+                    (fact "with changed url it registers the app"
+                          (register "localhost" 8761 "myId" 1234) => anything
+                          (provided
+                            (rand-int 10000) => 1
+                            (http/post
+                              "http://localhost:8761/eureka/apps/myId"
+                              (contains example-request)) => anything))
+                    (fact "with changed url it finds all instances of an app, second call cached"
+                          fact "it finds all instances of an app (second call cached)"
+                          (find-instances "localhost" 8761 "otherId") => '({:ip "192.168.178.38" :port 10100}
+                                                                         {:ip "192.168.178.38" :port 11100})
+                          (provided
+                            (http/get "http://localhost:8761/eureka/apps/otherId" anything) => example-response)
+
+                          (find-instances "localhost" 8761 "otherId") => '({:ip "192.168.178.38" :port 10100}
+                                                                         {:ip "192.168.178.38" :port 11100})
+                          (provided
+                            (http/get "http://localhost:8761/eureka/apps/otherId" anything) => anything :times 0)))


### PR DESCRIPTION
Changes in newer versions of eureka broke the library:
- the url to the rest api changed from /eureka/apps to /eureka/v2/apps
- the JSON format changed a bit
I have changed the code to conform to these changes. I also introduced the possibility to change the server url and unregister a service. Also the tests are changed accordingly and the dependency versions are updated.